### PR TITLE
bool Hash_Map::contains(Key)

### DIFF
--- a/aids.hpp
+++ b/aids.hpp
@@ -1165,6 +1165,10 @@ namespace aids
             }
         }
 
+        bool contains(Key key) {
+            return get(key).has_value;
+        }
+
         Value *operator[](Key key)
         {
             {

--- a/examples/hashmap.cpp
+++ b/examples/hashmap.cpp
@@ -18,5 +18,8 @@ int main(int argc, char *argv[])
     *map["baz"_sv] = 2020.f;
     assert(2020.f == *map["baz"_sv]);
 
+    assert(true == map.contains("baz"_sv));
+    assert(false == map.contains("foobar"_sv));
+
     return 0;
 }


### PR DESCRIPTION
In my opinion, it is better to introduce `contains(Key)` just like in `Dynamic_Array::contains(T)`, because

 - by comparison, you instantly see that `Hash_Map::contains(Key)` does not iterate over memory, so it is faster than `Dynamic_Array::contains(T)`
 - Previously, I wrote `Hash_Map::contains`, which iterates over every single bucket (!), because I missed that fact, that I could have reused `get(Key)`. Maybe I was the only one, who cannot think, but I want to make *library users'* life easier. Just in case.