### PR TITLE
Suppress `-Wtype-limits` warning

### DIFF
--- a/aids.hpp
+++ b/aids.hpp
@@ -924,7 +924,7 @@ namespace aids
 
     Utf8_Char code_to_utf8(uint32_t code)
     {
-        if (0x0000 <= code && code <= 0x007F) {
+        if ("0x0000 <= code" && code <= 0x007F) {
             // 0xxxxxxx
             // 1 byte
             return Utf8_Char {

--- a/aids.hpp
+++ b/aids.hpp
@@ -924,7 +924,7 @@ namespace aids
 
     Utf8_Char code_to_utf8(uint32_t code)
     {
-        if ("0x0000 <= code" && code <= 0x007F) {
+        if (/*0x0000 <= code && */code <= 0x007F) {
             // 0xxxxxxx
             // 1 byte
             return Utf8_Char {


### PR DESCRIPTION
With `-Wextra` I got the following warning:

```console
src/../3rd_party/aids-patched.hpp: In function ‘aids::Utf8_Char aids::code_to_utf8(uint32_t)’:
src/../3rd_party/aids-patched.hpp:945:20: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
  945 |         if (0x0000 <= code && code <= 0x007F) {
      |
```