### PR TITLE
(#8) Require Hashable Key in Hash_Map<Key, Value>

### DIFF
--- a/aids.hpp
+++ b/aids.hpp
@@ -1088,7 +1088,16 @@ namespace aids
         return hash;
     }
 
+#if __cplusplus > 201709
+    template <typename T>
+    concept Hashable = requires(T a, T b) {
+        { hash(a) };
+        { a != b };
+    };
+    template <Hashable Key, typename Value>
+#else
     template <typename Key, typename Value>
+#endif
     struct Hash_Map
     {
         struct Bucket


### PR DESCRIPTION
With c++20 enabled and commented out operator!= for custom structure, the compilation error message is more helpful.

```console
custom_struct_as_hashmap_key.cpp: In function ‘int main(int, char**)’:
custom_struct_as_hashmap_key.cpp:36:28: error: template constraint failure for ‘template<class Key, class Value>  requires  Hashable<Key> struct aids::Hash_Map’
   36 |     aids::Hash_Map<Foo, int> map{};
      |                            ^
custom_struct_as_hashmap_key.cpp:36:28: note: constraints not satisfied
In file included from custom_struct_as_hashmap_key.cpp:1:
../aids.hpp:1093:13:   required for the satisfaction of ‘Hashable<Key>’ [with Key = Foo]
../aids.hpp:1093:24:   in requirements with ‘T a’, ‘T b’ [with T = Foo]
../aids.hpp:1095:13: note: the required expression ‘(a != b)’ is invalid
 1095 |         { a != b };
      |           ~~^~~~
cc1plus: note: set ‘-fconcepts-diagnostics-depth=’ to at least 2 for more detail
```