### PR TITLE
[0.36.0] Release

### DIFF
--- a/aids.hpp
+++ b/aids.hpp
@@ -30,7 +30,7 @@
 //
 // ChangeLog (https://semver.org/ is implied)
 //
-//   0.35.1 Fix compilation when using todo() and unreachable()
+//   0.36.0 Fix compilation when using todo() and unreachable()
 //   0.35.0 [[noreturn]] void unreachable(Args... args)
 //          [[noreturn]] void todo(Args... args)
 //   0.34.1 Fix -Wtype-limits warning in utf8_get_code()


### PR DESCRIPTION
This is a breaking change, so I re-released it under a new minor version. As I already depend on that behaviour for a critical part of my software, 0.35.1 is going to break my whole software stack.