### PR TITLE
Replace `chop` w/ `chop_left` in `as_integer()`

### DIFF
--- a/aids.hpp
+++ b/aids.hpp
@@ -396,7 +396,7 @@ struct String_View {
 
         if (*view.data == '-') {
             sign = -1;
-            view.chop(1);
+            view.chop_left(1);
         }
 
         while (view.count) {
@@ -404,7 +404,7 @@ struct String_View {
                 return {};
             }
             number = number * 10 + (*view.data - '0');
-            view.chop(1);
+            view.chop_left(1);
         }
 
         return { true, number * sign };

--- a/tests/string_view_test.cpp
+++ b/tests/string_view_test.cpp
@@ -97,5 +97,12 @@ int main(int, char *[])
             ASSERT_EQ(""_sv, bar);
         }
     }
+    // String_View::as_integer<int>
+    {
+        auto year = "2021"_sv;
+        int number = unwrap_or_panic(year.as_integer<int>());
+        number += 1000;
+        ASSERT_EQ(3021, number);
+    }
     return 0;
 }


### PR DESCRIPTION
```console

In file included from string_view_test.cpp:2:0:
../aids.hpp: In instantiation of ‘aids::Maybe<T> aids::String_View::as_integer() const [with Integer = int]’:
string_view_test.cpp:103:59:   required from here
../aids.hpp:399:22: warning: ‘void aids::String_View::chop(size_t)’ is deprecated: Please use String_View::chop_left() instead, komrade)) [-Wdeprecated-declarations]
             view.chop(1);
             ~~~~~~~~~^~~
../aids.hpp:934:6: note: declared here
 void String_View::chop(size_t n)
      ^~~~~~~~~~~

```